### PR TITLE
fix: Simplify markdown structure in CLAUDE.md guidance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,9 +300,9 @@ The xclaude-plugin provides 8 modular MCPs with 22 specialized iOS tools. **Alwa
 
 ### Critical: Prefer Plugin Tools Over Bash
 
-When you encounter a task that could use either approach, **always choose the plugin tool**:
+When you encounter a task that could use either approach, **always choose the plugin tool**.
 
-❌ **Don't do this:**
+**Don't do this:**
 
 ```bash
 # Manual build parsing
@@ -310,13 +310,11 @@ xcodebuild -scheme MyApp 2>&1 | grep -A5 "error:" | sed ...
 ```
 ````
 
-✅ **Do this instead:**
+**Do this instead:** Use the `xcode_build` tool from `xc-compile` MCP.
 
-```
-Use the xcode_build tool from xc-compile MCP
-```
+---
 
-❌ **Don't do this:**
+**Don't do this:**
 
 ```bash
 # Manual screenshot saving
@@ -324,24 +322,18 @@ xcrun simctl io booted screenshot /tmp/screenshot.png
 cat /tmp/screenshot.png | base64
 ```
 
-✅ **Do this instead:**
+**Do this instead:** Use the `simulator_screenshot` tool from `xc-interact` MCP.
 
-```
-Use the simulator_screenshot tool from xc-interact MCP
-```
+---
 
-❌ **Don't do this:**
+**Don't do this:**
 
 ```bash
 # Finding UI elements by trial and error
 xcrun simctl spawn booted launchctl list | grep bundleid
 ```
 
-✅ **Do this instead:**
-
-```
-Use idb_describe tool to query accessibility tree, then idb_tap to interact
-```
+**Do this instead:** Use `idb_describe` tool to query accessibility tree, then `idb_tap` to interact.
 
 ### Why Enable ONE MCP at a Time
 


### PR DESCRIPTION
## Summary

Improves readability by simplifying the "Don't do this / Do this instead" examples. The previous format created confusion with nested code blocks and emoji separators. This version uses inline formatted text and horizontal dividers for cleaner presentation.

## Changes

- **Before**: ❌ with code block, then separate ✅ with another code block
- **After**: Clean inline text with backtick-formatted tool names + horizontal dividers (`---`)

The markdown now renders cleanly with proper visual separation between examples, making it easier for agents to parse the guidance.

## Note on Backticks

Uses 4 backticks for the outer code block (to properly escape inner backticks) - this is valid Markdown and correctly handled by prettier.

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>